### PR TITLE
FE3 - SHA256 hashing geimplementeerd als checksum

### DIFF
--- a/TcpClient/TcpClient.csproj
+++ b/TcpClient/TcpClient.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/TcpClient/client.cs
+++ b/TcpClient/client.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Net.WebSockets;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -13,6 +14,10 @@ namespace TcpServer
         private static ILogger<WebSocketFileClient> _logger = null!;
         private static ClientWebSocket? _notificationSocket;
         private static readonly ConcurrentDictionary<string, long> LastNotificationTimes = new();
+        private static readonly string[] IgnoredPrefixes = ["~$", "."];
+        private static readonly string[] IgnoredSuffixes = [".swp", ".tmp", ".lock", ".part", ".crdownload", ".download", ".bak", ".old", ".temp", ".sha256"
+        ];
+
 
         // Cancellation token for the notification receiver
         private static CancellationTokenSource? _notificationCts;
@@ -175,6 +180,22 @@ Available commands:
                 retryDelay = Math.Min(retryDelay * 2, 30000); // Max delay of 30 seconds
             }
         }
+        
+        private static async Task<string?> ComputeFileHashAsync(string filePath)
+        {
+            try
+            {
+                using var sha256 = SHA256.Create();
+                await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var hashBytes = await sha256.ComputeHashAsync(stream);
+                return BitConverter.ToString(hashBytes).Replace("-", "").ToLowerInvariant();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error computing hash for file {FilePath}: {Message}", filePath, ex.Message);
+                throw;
+            }
+        }
 
         /// <summary>
         /// Sends a notification message to the server. 
@@ -194,13 +215,9 @@ Available commands:
                 timestamp, // If new entry, store timestamp
                 (_, lastSent) =>
                 {
-                    if (timestamp - lastSent < 5)
-                    {
-                        _logger.LogWarning($"Skipping duplicate notification for '{filename}' within cooldown period.");
-                        return lastSent; // Keep existing timestamp
-                    }
-
-                    return timestamp; // Update timestamp
+                    if (timestamp - lastSent >= 5) return timestamp; // Update timestamp
+                    _logger.LogWarning($"Skipping duplicate notification for '{filename}' within cooldown period.");
+                    return lastSent; // Keep existing timestamp
                 });
 
             // **Ignore empty files to prevent premature uploads**
@@ -208,6 +225,22 @@ Available commands:
             {
                 _logger.LogWarning($"Ignoring file '{filename}' because its size is 0 bytes.");
                 return;
+            }
+            
+            // Compute hash only for created or modified events and if file exists.
+            string? fileHash = null;
+            if ((eventType.Equals("created", StringComparison.OrdinalIgnoreCase) ||
+                 eventType.Equals("modified", StringComparison.OrdinalIgnoreCase)) && File.Exists(fullPath))
+            {
+                try
+                {
+                    fileHash = await ComputeFileHashAsync(fullPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError("Failed to compute hash for '{FileName}': {Message}", filename, ex.Message);
+                    // Depending on your policy, you could continue without the hash or abort sending notification.
+                }
             }
 
             // **Ensure WebSocket connection is alive**
@@ -228,7 +261,8 @@ Available commands:
                 @event = eventType,
                 filename = filename,
                 timestamp = timestamp,
-                size = fileSize
+                size = fileSize,
+                hash = fileHash  // Will be null if not computed
             };
 
             var json = JsonConvert.SerializeObject(notification);
@@ -237,7 +271,7 @@ Available commands:
                 CancellationToken.None);
 
             Console.WriteLine(
-                $"[INFO] Sent notification: File '{filename}' {eventType} at {timestamp} (size: {fileSize} bytes)");
+                $"[INFO] Sent notification: File '{filename}' {eventType} at {timestamp} (size: {fileSize} bytes){(fileHash != null ? $" hash: {fileHash}" : string.Empty)}");
         }
 
         private static async Task ReconnectNotificationSocketAsync()
@@ -561,6 +595,16 @@ Available commands:
                 _logger.LogError("Error listing files: {Message}", ex.Message);
             }
         }
+        
+        /// <summary>
+        /// Returns true if the file should be ignored based on its name.
+        /// </summary>
+        private static bool ShouldIgnoreFile(string filePath)
+        {
+            var fileName = Path.GetFileName(filePath);
+            return IgnoredPrefixes.Any(prefix => fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                   || IgnoredSuffixes.Any(suffix => fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        }
 
         private static void StartLocalFileWatcher()
         {
@@ -574,7 +618,7 @@ Available commands:
 
             watcher.Created += async (_, e) =>
             {
-                if (Path.GetFileName(e.FullPath).StartsWith("~$") || Path.GetFileName(e.FullPath).StartsWith("."))
+                if (ShouldIgnoreFile(Path.GetFullPath(e.FullPath)))
                     return; // Ignore temp files
                 await Task.Delay(500); // Prevent duplicate rapid events
                 Console.WriteLine($"[LOCAL] File created: {e.Name}");
@@ -583,8 +627,8 @@ Available commands:
 
             watcher.Changed += async (_, e) =>
             {
-                if (Path.GetFileName(e.FullPath).StartsWith("~$") || Path.GetFileName(e.FullPath).StartsWith("."))
-                    return;
+                if (ShouldIgnoreFile(Path.GetFullPath(e.FullPath)))
+                    return; // Ignore temp files
                 await Task.Delay(500); // Prevent multiple rapid events
                 Console.WriteLine($"[LOCAL] File changed: {e.Name}");
                 await SendNotificationAsync("modified", e.FullPath);
@@ -592,8 +636,8 @@ Available commands:
 
             watcher.Deleted += async (_, e) =>
             {
-                if (Path.GetFileName(e.FullPath).StartsWith("~$") || Path.GetFileName(e.FullPath).StartsWith("."))
-                    return;
+                if (ShouldIgnoreFile(Path.GetFullPath(e.FullPath)))
+                    return; // Ignore temp files
                 Console.WriteLine($"[LOCAL] File deleted: {e.Name}");
                 await SendNotificationAsync("deleted", e.FullPath, useFileTime: false);
             };


### PR DESCRIPTION
Dit pull request introduceert de implementatie van SHA256-hashing in ons protocol. 

**Hybride variant van metadate en checksum**
Deze wijziging verbetert de integriteit en veiligheid van onze synchronisatie door naast traditionele metadata (zoals bestandsgrootte en timestamp) ook een SHA256-hash van het bestand te versturen en te vergelijken. Dit zorgt ervoor dat we nauwkeurig kunnen bepalen of de inhoud van een bestand daadwerkelijk is gewijzigd. 

**Caching mechanisme**
Tevens is er een cachingmechanisme toegevoegd op de serverzijde, waarbij de hash wordt opgeslagen in een .sha256-bestand, zodat deze niet bij iedere notificatie opnieuw berekend hoeft te worden.

---

**Wijzigingen aan de serverzijde**

- JSON Notificaties:
De notificatie-berichten die naar de clients worden gestuurd, bevatten nu een extra veld hash met de SHA256-hash van het bestand. Dit maakt een diepgaandere integriteitscontrole mogelijk.

- Hash Caching:
Een nieuw cachingmechanisme is geïmplementeerd. De functie get_cached_hash controleert of er een up-to-date .sha256-bestand bestaat voor een gegeven bestand. Als dit bestand aanwezig en actueel is, wordt de opgeslagen hash gebruikt; anders wordt de hash opnieuw berekend en opgeslagen. Hierdoor wordt de rekenbelasting verminderd.

- Verificatie in handle_client_notification:
Bij ontvangst van een notificatie vergelijkt de server nu niet alleen de metadata, maar ook de SHA256-hash. Indien de hash van de client niet overeenkomt met de gecachte hash van het bestand op de server, wordt een REQUEST_UPLOAD-bericht verstuurd om een nieuwe upload af te dwingen.

- Ignore Logic:
De functie should_ignore is aangepast zodat bestanden met de extensie .sha256 (en andere tijdelijke of ongewenste bestanden) worden genegeerd. Dit voorkomt een oneindige lus van notificaties voor de hashbestanden.

---

**Wijzigingen aan de clientzijde**
- Hash Berekening en Notificaties:
De client berekent nu de SHA256-hash van een bestand wanneer een notificatie wordt verstuurd. Deze hash wordt samen met andere metadata (zoals timestamp en bestandsgrootte) als onderdeel van de JSON payload meegezonden. Hierdoor kan de server een nauwkeurigere controle uitvoeren op de inhoud van het bestand.

- Local File Watcher:
De local file watcher is aangepast om ook bestanden met bepaalde ongewenste suffixen, waaronder .sha256, te negeren. Dit voorkomt dat de client onnodige notificaties verstuurt voor de hashbestanden.

Ook heb ik deze implmentatie toegevoegd aan de documentatie in ons hoofddocument en ons gedeeld protocol document met het andere team.