### PR TITLE
moved hard coded serverUrl to config file for security reasons

### DIFF
--- a/TcpClient/TcpClient.csproj
+++ b/TcpClient/TcpClient.csproj
@@ -9,6 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.0-preview.1.25080.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.1.25080.5" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>


### PR DESCRIPTION
Moved hard coded server URL of the remote machine to a config file.
Introduced Microsoft.Extensions.Configuration.FileExtensions and Microsoft.Extensions.Configuration.Json packages for building a config file to securely store the server URL.